### PR TITLE
Add ArchBang Live Iso boot entry configuration

### DIFF
--- a/efiboot/loader/entries/02-archbang-x86_64-linux-nomodeset.conf
+++ b/efiboot/loader/entries/02-archbang-x86_64-linux-nomodeset.conf
@@ -1,0 +1,5 @@
+title    ArchBang Live Iso [labwc] (x86_64, UEFI) Basic Graphics Mode
+sort-key 02
+linux    /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
+initrd   /%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
+options  archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% cow_spacesize=4G nomodeset


### PR DESCRIPTION
nomodeset fallback graphics mode required for booting in certain enviroments such as vSphere

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new boot entry for ArchBang Live ISO (x86_64, UEFI) in basic graphics mode, enabling system startup without advanced graphics module support for systems with graphics compatibility issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->